### PR TITLE
fix: syntax_on check is always true

### DIFF
--- a/lua/silentium.lua
+++ b/lua/silentium.lua
@@ -44,7 +44,7 @@ function M.colorscheme()
 	vim.o.background = "dark"
 	vim.g.colors_name = "silentium"
 	vim.cmd.highlight("clear")
-	if vim.fn.has("syntax_on") then
+	if vim.fn.exists("syntax_on") == 1 then
 		vim.cmd.syntax("reset")
 	end
 


### PR DESCRIPTION
Firstly, has() and exists() return 0/1, so the condition is always true in Lua.

Secondly, has() checks feature support, but what we want is to check whether 'syntax_on' is defined.