### PR TITLE
fix: improve winbar highlighting

### DIFF
--- a/lua/silentium.lua
+++ b/lua/silentium.lua
@@ -126,8 +126,8 @@ function M.colorscheme()
 	hl("Type", { fg = M.colors.white })
 	hl("Visual", { bg = M.colors.dark_gray })
 	hl("WarningMsg", { fg = M.accents.yellow })
-	hl("WinBar", { bg = M.colors.accent, fg = M.colors.dark })
-	hl("WinBarNC", { bg = M.colors.accent, fg = M.colors.dark })
+	hl("WinBar", { bg = M.colors.ghost })
+	hl("WinBarNC", { bg = M.colors.dark_gray })
 	hl("WinSeparator", { fg = M.colors.gray })
 
 	vim.g.terminal_color_0 = M.colors.dark_gray


### PR DESCRIPTION
## Le probleme

With the default accent color, the WinBar background matches the WarningMsg foreground, which makes the `:checkhealth` winbar unreadable.

<img width="2560" height="472" alt="before" src="https://github.com/user-attachments/assets/f5b19211-3a00-4634-ab44-de25f910149e" />


## La solutione

Since changing WarningMsg is not an option, change WinBar to use the 'ghost' color instead. Also make WinBarNC distinct.

<img width="2560" height="480" alt="after" src="https://github.com/user-attachments/assets/c2b56064-cc2d-41f0-94d3-477c079824b3" />