### PR TITLE
Fix colorscheme initialization

### DIFF
--- a/lua/silentium.lua
+++ b/lua/silentium.lua
@@ -41,8 +41,8 @@ local function hl(name, val)
 end
 
 function M.colorscheme()
-	vim.g.colors_name = "silentium"
 	vim.cmd.highlight("clear")
+	vim.g.colors_name = "silentium"
 	if vim.fn.exists("syntax_on") == 1 then
 		vim.cmd.syntax("reset")
 	end

--- a/lua/silentium.lua
+++ b/lua/silentium.lua
@@ -41,7 +41,6 @@ local function hl(name, val)
 end
 
 function M.colorscheme()
-	vim.o.background = "dark"
 	vim.g.colors_name = "silentium"
 	vim.cmd.highlight("clear")
 	if vim.fn.exists("syntax_on") == 1 then

--- a/lua/silentium.lua
+++ b/lua/silentium.lua
@@ -43,9 +43,6 @@ end
 function M.colorscheme()
 	vim.cmd.highlight("clear")
 	vim.g.colors_name = "silentium"
-	if vim.fn.exists("syntax_on") == 1 then
-		vim.cmd.syntax("reset")
-	end
 
 	hl("@constant.html", { fg = M.colors.light_gray })
 	hl("@tag", { fg = M.colors.accent })


### PR DESCRIPTION
Fixes some bugs and removes unneeded steps. 

* fix: do not force 'background' option
* fix: set 'colors_name' after ":hi clear"
* fix: remove ":syntax reset" call